### PR TITLE
fix: add missing react methods

### DIFF
--- a/android/src/main/java/com/reactnativegeetestmodule/GeetestModuleModule.java
+++ b/android/src/main/java/com/reactnativegeetestmodule/GeetestModuleModule.java
@@ -157,4 +157,14 @@ public class GeetestModuleModule extends ReactContextBaseJavaModule {
                 .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                 .emit(eventName, params);
     }
+
+    @ReactMethod
+    public void addListener(String eventName) {
+        // Set up any upstream listeners or background tasks as necessary
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Remove upstream listeners, stop unnecessary background tasks
+    }
 }


### PR DESCRIPTION
This PR fixes the `NativeEventEmitter()` warnings coming from react-native 0.65 by adding the missing methods.

Closes https://github.com/GaloyMoney/react-native-geetest-module/issues/2